### PR TITLE
Geometry calculations

### DIFF
--- a/constraints.py
+++ b/constraints.py
@@ -2,6 +2,7 @@ import numpy
 from costs import materials
 from classes import Parameters, Design
 
+
 def table_K1(Flv, l_spacing):
     """Figure 11-27
     
@@ -42,6 +43,7 @@ CONSTRAINT_NAMES = ["Flooding",
                     "Weeping",
                     "Downcomer backup",
                     "Residence time"]
+
 
 def columnconstraints(parameters, design):
     L, V, rho_l, rho_v, sigma, turn_down, t_shell, l_calm, Nplates = parameters
@@ -110,6 +112,7 @@ def columnconstraints(parameters, design):
     
     return _constraints(V, L) + _constraints(V*turn_down, L*turn_down)
 
+
 def check_design(parameters, design):
 
     print("Parameters:")
@@ -129,6 +132,7 @@ def check_design(parameters, design):
     print("Cost:")
 
     print(materials(parameters, design))
+
 
 if __name__ == "__main__":
     # We check the design in Example 11.2 and Example 11.11 in C+R

--- a/costs.py
+++ b/costs.py
@@ -10,7 +10,7 @@ def materials(parameters, design):
     spacing = design.l_spacing
 
     r = diameter/2
-    shell_cost = numpy.pi*r*shell_thickness*spacing
+    shell_cost = (numpy.pi*diameter)*(plates*spacing)*shell_thickness  # circumference * height * thickness
     plate_area = numpy.pi*r**2
     downcomer_area = (angle - numpy.sin(angle))*r**2/2
     plate_cost = plates*plate_thickness*(plate_area - downcomer_area)

--- a/costs.py
+++ b/costs.py
@@ -1,5 +1,6 @@
 import numpy
 
+
 def materials(parameters, design):
 
     diameter = design.d_col


### PR DESCRIPTION
I believe that the geometry calculation may be wrong.
It was initially calculated as:
`shell_cost = pi*r*shell_thickness*spacing`
I believe that it should be calculated as:
`shell_cost = circumference * height * thickness = (pi*diameter)*(plates*spacing)*shell_thickness`
Although I may be wrong.

I also fixed the PEP8 spacing errors which were bugging me in PyCharm.